### PR TITLE
Fix if coming from not A5 task

### DIFF
--- a/d2bs/kolbot/libs/horde/sequences/barbrescue.js
+++ b/d2bs/kolbot/libs/horde/sequences/barbrescue.js
@@ -86,6 +86,9 @@ function barbrescue(mfRun) { // SiC-666 TODO: Rewrite this.
 		delay(1000);
 		Town.goToTown();
 	}
+	
+	Town.goToTown(5);
+	delay(1000+me.ping);
 	Town.move("qual-kehk");
 	delay(1000+me.ping);
 	qual = getUnit(1, "qual-kehk");


### PR DESCRIPTION
followers fail to be in A5 if task before was not in A5