### PR TITLE
Improvements baal

### DIFF
--- a/d2bs/kolbot/libs/horde/sequences/baal.js
+++ b/d2bs/kolbot/libs/horde/sequences/baal.js
@@ -413,7 +413,8 @@ BaalLoop:
 	}
 	Pather.moveTo(15134, 5923);
 	var baalded = false;
-	while(!baalded){
+	var baalloop = getTickCount() + 3*60*1000;
+	while(!baalded && getTickCount() < baalloop){
 		try{
 			if (Attack.kill(544)) {
 				baalded = true;


### PR DESCRIPTION
turn finditem on for throne for barb
extended battle logic to prevent non-attacker (necro) from leaving
turn teleport off to conserve mana in normal