### PR TITLE
Update MuleLogger.js

### DIFF
--- a/d2bs/kolbot/libs/MuleLogger.js
+++ b/d2bs/kolbot/libs/MuleLogger.js
@@ -38,7 +38,7 @@ var MuleLogger = {
 			logIlvl = this.LogItemLevel;
 		}
 
-		desc = unit.description.split("\n");
+		//desc = unit.description.split("\n");
 
 		if (!!unit.description)
 		{


### PR DESCRIPTION
Fix for: 
  Error in Horde (mulelogger.js #41) unit.description is undefined (Area: 1, Ping:157, Game:----)