### PR TITLE
Fixes

### DIFF
--- a/d2bs/kolbot/libs/common/Cubing.js
+++ b/d2bs/kolbot/libs/common/Cubing.js
@@ -933,7 +933,7 @@ IngredientLoop:
 					return false;
 				}
 
-				this.cursorCheck();
+				Misc.cursorCheck();
 
 				i = -1;
 
@@ -995,34 +995,6 @@ IngredientLoop:
 				me.cancel();
 				delay(300);
 			}
-		}
-
-		return true;
-	},
-
-	cursorCheck: function () {
-		var item;
-
-		if (me.itemoncursor) {
-			item = getUnit(100);
-
-			if (item) {
-				if (Storage.Inventory.CanFit(item) && Storage.Inventory.MoveTo(item)) {
-					return true;
-				}
-
-				if (Storage.Stash.CanFit(item) && Storage.Stash.MoveTo(item)) {
-					return true;
-				}
-
-				Misc.itemLogger("Dropped", item, "cursorCheck");
-
-				if (item.drop()) {
-					return true;
-				}
-			}
-
-			return false;
 		}
 
 		return true;

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -1684,6 +1684,36 @@ var Misc = {
 		return false;
 	},
 
+	// Handle stuck item on the cursor. Inventory > Stash > Drop (Try Pickit if dropped)
+	cursorCheck: function () {
+		var item;
+
+		if (me.itemoncursor) {
+			item = getUnit(100);
+
+			if (item) {
+				if (Storage.Inventory.CanFit(item) && Storage.Inventory.MoveTo(item)) {
+					return true;
+				}
+
+				if (Storage.Stash.CanFit(item) && Storage.Stash.MoveTo(item)) {
+					return true;
+				}
+
+				Misc.itemLogger("Dropped", item, "cursorCheck");
+
+				if (item.drop()) {
+					Pickit.pickItems();
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return true;
+	},
+
 	// Go to town when low on hp/mp or when out of potions. can be upgraded to check for curses etc.
 	townCheck: function () {
 		var i, potion, check,
@@ -2994,7 +3024,9 @@ Item.autoEquipMerc = function () {
 					
                     if (this.equipMerc(items[0], bodyLoc[j])) {
                         Misc.logItem("Merc Equipped", equippedItem,"Merc Tier: "+tier);
-                    }
+					}
+
+					Misc.cursorCheck();
 
                     break;
                 }

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -3022,8 +3022,8 @@ Item.autoEquipMerc = function () {
 					
 					print("Merc equip [" + bodyLoc[j] + "] : " + items[0].name + " - tier " + tier + " | Remove " + equippedItem.name + " - tier " + equippedTier);
 					
-                    if (this.equipMerc(items[0], bodyLoc[j])) {
-                        Misc.logItem("Merc Equipped", equippedItem,"Merc Tier: "+tier);
+					if (this.equipMerc(items[0], bodyLoc[j])) {
+						Misc.logItem("Merc Equipped", equippedItem,"Merc Tier: "+tier);
 					}
 
 					Misc.cursorCheck();

--- a/d2bs/kolbot/libs/common/Storage.js
+++ b/d2bs/kolbot/libs/common/Storage.js
@@ -463,6 +463,8 @@ Loop:
 			}
 		}
 
+		Misc.cursorCheck();
+
 		return true;
 	};
 

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -1999,7 +1999,7 @@ MainLoop:
 	},
 
 	sortInventory: function() {
-			Storage.Inventory.SortItems(Config.ItemsSortedFromLeft, Config.ItemsSortedFromRight);
+		Storage.Inventory.SortItems(Config.ItemsSortedFromLeft, Config.ItemsSortedFromRight);
 
 		return true;
 	},

--- a/d2bs/kolbot/libs/horde/builds/templates/skills/Sorceress.js
+++ b/d2bs/kolbot/libs/horde/builds/templates/skills/Sorceress.js
@@ -42,8 +42,8 @@ var SkillsBuilds = {
 		[38, 2, false], //Charged bolt
 		[42, 2, false], //Static
 		[42, 3, false], //Static
-		[48, 1, false],  //Nova
 		[49, 1, false], //Lightning
+		[48, 1, false],  //Nova
 		[38, 4, false], //Charged bolt
 		[54, 1, false], //Teleport
 		[53, 10, false], //Chain lightning

--- a/d2bs/kolbot/libs/horde/common/Horde.js
+++ b/d2bs/kolbot/libs/horde/common/Horde.js
@@ -446,6 +446,7 @@ var HordeSystem = {
 	},
 	
 	preRunSetup: function() {
+		Misc.cursorCheck(); // handle any items that could be stuck on the cursor before doing anything else
 		Town.reviveMerc();
 		this.setupRunewords(this.team.profiles[me.profile].runewordsProfile);
 		Runewords.init();

--- a/d2bs/kolbot/libs/horde/common/Waypoint.js
+++ b/d2bs/kolbot/libs/horde/common/Waypoint.js
@@ -143,6 +143,10 @@ var Waypoint = {
 
 				delay(1000);
 			}
+
+			if (!me.getQuest(21, 0)) {
+				return false; // still can't take the tp, skip this one
+			}
 		}
 
 		// if (index === 33 && me.getQuest(39, 0)) { // SiC-666 TODO: Worldstone Keep Level 2 requires the completion of Rite of Passage, but talking to someone won't help. Is there anything that would help if this situation arises?

--- a/d2bs/kolbot/libs/horde/sequences/cain.js
+++ b/d2bs/kolbot/libs/horde/sequences/cain.js
@@ -32,70 +32,64 @@ function cain(mfRun) { // Dark-f: rewrite rescue cain
 				Travel.travel(0);
 		}
 		
-		if (!me.getQuest(4, 4) && !me.getQuest(4, 3) ) {
-			if (!me.getItem(524)) { 	// Scroll of Inifuss
-				if (!me.inTown) {
-					Role.backToTown();
-				}
-				if (me.diff === 0 ) {
-					Pather.useWaypoint(5); //dark wood
-				} else {
-					if (Role.teleportingChar ) {
-						Pather.useWaypoint(5); //dark wood
-						Pather.makePortal();
-					} else {
-						Town.move("portalspot");
-						var j = 0;
-						while (!Pather.usePortal(5, null)) {
-							delay(250);
-							if (j % 20 == 0) { // Check for Team Members every 5 seconds.
-								Party.wholeTeamInGame();
-							}
-							j += 1;
-							if (me.getQuest(4, 0))
-							{
-								return Sequencer.done;
-							}
-						}
-					}
-				}
-				Party.waitForMembers();
-
-				Precast.doPrecast(true);
-				Buff.Bo();
-				Pather.teleport = false;
-				Pather.moveToPreset(me.area, 1, 738, 0, 0, true, true); //move to tree
-				Attack.clear(40); // treehead
-
-				if (Role.teleportingChar) {
-					Quest.getQuestItem(524, 30);
-				} 
-				
+		if (!me.getItem(524)) { 	// Scroll of Inifuss
+			if (!me.inTown) {
 				Role.backToTown();
-				
-			/*	scroll1 = me.getItem(524);
-				if (scroll1) {
-					if ( scroll1.location !== 7 && Storage.Stash.CanFit(scroll1)) {
-						Storage.Stash.MoveTo(scroll1);
-						delay(me.ping + 1);
-						me.cancel();
+			}
+			if (me.diff === 0 ) {
+				Pather.useWaypoint(5); //dark wood
+			} else {
+				if (Role.teleportingChar ) {
+					Pather.useWaypoint(5); //dark wood
+					Pather.makePortal();
+				} else {
+					Town.move("portalspot");
+					var j = 0;
+					while (!Pather.usePortal(5, null)) {
+						delay(250);
+						if (j % 20 == 0) { // Check for Team Members every 5 seconds.
+							Party.wholeTeamInGame();
+						}
+						j += 1;
 					}
-				}*/
+				}
 			}
-			Town.move("akara");
-			akara = getUnit(1, "akara");
-			if (akara && akara.openMenu()) {
-				me.cancel();
+			Party.waitForMembers();
+
+			Precast.doPrecast(true);
+			Buff.Bo();
+			Pather.teleport = false;
+			Pather.moveToPreset(me.area, 1, 738, 0, 0, true, true); //move to tree
+			Attack.clear(40); // treehead
+
+			if (Role.isLeader) {
+				Quest.getQuestItem(524, 30);
 			}
-		/*	scroll2 = me.getItem(525);
-			if (scroll2) {
-				if ( scroll2.location !== 7 && Storage.Stash.CanFit(scroll2)) {
-					Storage.Stash.MoveTo(scroll2);
+			
+			Role.backToTown();
+			
+		/*	scroll1 = me.getItem(524);
+			if (scroll1) {
+				if ( scroll1.location !== 7 && Storage.Stash.CanFit(scroll1)) {
+					Storage.Stash.MoveTo(scroll1);
 					delay(me.ping + 1);
 					me.cancel();
 				}
 			}*/
 		}
+		Town.move("akara");
+		akara = getUnit(1, "akara");
+		if (akara && akara.openMenu()) {
+			me.cancel();
+		}
+	/*	scroll2 = me.getItem(525);
+		if (scroll2) {
+			if ( scroll2.location !== 7 && Storage.Stash.CanFit(scroll2)) {
+				Storage.Stash.MoveTo(scroll2);
+				delay(me.ping + 1);
+				me.cancel();
+			}
+		}*/
 
 		Party.wholeTeamInGame();
 		if (Role.teleportingChar) {
@@ -107,11 +101,6 @@ function cain(mfRun) { // Dark-f: rewrite rescue cain
 			Town.move("portalspot");
 			while (!Pather.usePortal(4, null)) {
 				delay(250);
-				
-				if (me.getQuest(4, 0))
-				{
-					return Sequencer.done;
-				}
 			}
 		}
 		Party.waitForMembers();
@@ -142,7 +131,7 @@ function cain(mfRun) { // Dark-f: rewrite rescue cain
 		}
 		if ( me.diff > 0 ) {
 			// Dark-f: now only leader finish the next job when Nightmare & Hell
-			if (Role.teleportingChar) {
+			if (Role.isLeader) {
 				Pather.teleport = true;
 				for (i = 0; i < 5; i += 1) {
 					if (Pather.usePortal(38)) {

--- a/d2bs/kolbot/libs/horde/sequences/den.js
+++ b/d2bs/kolbot/libs/horde/sequences/den.js
@@ -51,7 +51,7 @@ function den(mfRun) {
 
 			delay(me.ping * 2 + 250);
 
-			if (me.getQuest(1, 1)) { // Den is cleared. Return to Akara for a Reward.
+			if (me.getQuest(1, 0) || me.getQuest(1, 1)) { // Den is cleared. Return to Akara for a Reward.
 				break;
 			}
 		}

--- a/d2bs/kolbot/libs/horde/sequences/lamesen.js
+++ b/d2bs/kolbot/libs/horde/sequences/lamesen.js
@@ -104,8 +104,7 @@ function lamesen(mfRun) {
 
 	Party.waitSynchro("book_picked");
 	
-	if (!me.getQuest(17,0)) {
-		delay(HordeSystem.getTeamIndex()*5000);
+	if (!me.getQuest(17,0) && me.getItem(548)) {
 		Town.move("alkor");
 
 		target = getUnit(1, "alkor");


### PR DESCRIPTION
**Sequences**
* den bug: needs to check both complete statuses. if a team member completes quest before all members check partial complete, then slower members will walk through den 2 more times - taking forever to finish.
* cain bug: if any team members have completed cain quest already, they won't sync with the others that need the quest
* lamesen bug: only the team member with the book needs to talk to alkor. when all go, they can get stuck on the bridges or slow down the one with the book.

**General**
* waypoint sharing bug: if a team member has not completed travincal, it will get stuck in infinite loop of trying to get durance 2 wp. when it happens, this bug prevents progression.
* light sorc build bug: at level 12, the sorc spends skill point on nova, and changes primary skill to lightning (which she doesn't have). she spend a whole level skipping monsters until 13. fixed here
* move cursorCheck() from Cubing to Misc. it's a good general function that should be used to get things unstuck from the cursor. it has been added to the prerun to prevent a stuck cursor item from causing problems or just being dropped.