### PR TITLE
Return to town if a team mate leaves the game

### DIFF
--- a/d2bs/kolbot/tools/ToolsThread.js
+++ b/d2bs/kolbot/tools/ToolsThread.js
@@ -428,6 +428,10 @@ function main() {
 					(Config.QuitList instanceof Array && Config.QuitList.indexOf(name1) > -1)) {
 				print(name1 + (mode === 0 ? " timed out" : " left"));
 
+				// we need to stall in town, not in the battlefield
+				this.togglePause();
+				!me.inTown && Town.goToTown();
+
 				if (typeof Config.QuitListDelay !== "undefined" && typeof quitListDelayTime === "undefined" && Config.QuitListDelay.length > 0) {
 					Config.QuitListDelay.sort(function(a, b){return a-b});
 					quitListDelayTime = getTickCount() + rand(Config.QuitListDelay[0] * 1e3, Config.QuitListDelay[1] * 1e3);


### PR DESCRIPTION
When a team mate leaves the game, other teammates now return to town before stalling and quitting.

Previously, they could remain idle in combat areas until leaving the game, exposing them to monster attacks and potential deaths. The new behavior ensures they wait in a safe location while the game-exit sequence completes.