### PR TITLE
fix(organize): use correct index for dropping keys

### DIFF
--- a/d2bs/kolbot/libs/horde/common/Storage.js
+++ b/d2bs/kolbot/libs/horde/common/Storage.js
@@ -22,7 +22,7 @@ var HordeStorage = {
 			if (k === 0 ) {
 				inventory.push({item: keys[k], x: 0, y: 2});
 			} else { //drop all key stacks after first
-				keys[i].drop();
+				keys[k].drop();
 			}
 		}
 			


### PR DESCRIPTION
Using the incorrect index in `keys[index].drop()` is problematic if we really need to drop keys